### PR TITLE
fix: message receiver id issue

### DIFF
--- a/src/main/java/unithon/team5/message/service/MessageService.java
+++ b/src/main/java/unithon/team5/message/service/MessageService.java
@@ -63,8 +63,8 @@ public class MessageService {
         Message findMessage = messageRepository.findById(id).orElseThrow(
                 () -> new NotFoundException(String.format("[%s] message id not found", id)));
 
-        if (findMessage.getReceiverId() != member.getId()) {
-            throw new ForbiddenException(String.format("[%s] message id's sender is not equal with current member", id));
+        if (!findMessage.getReceiverId().equals(member.getId())) {
+            throw new ForbiddenException(String.format("[%s] message id's receiver is not equal with current member [%s]", id, member.getId()));
         }
 
         return MessageResponse.of(findMessage);

--- a/src/main/java/unithon/team5/message/service/MessageService.java
+++ b/src/main/java/unithon/team5/message/service/MessageService.java
@@ -63,7 +63,7 @@ public class MessageService {
         Message findMessage = messageRepository.findById(id).orElseThrow(
                 () -> new NotFoundException(String.format("[%s] message id not found", id)));
 
-        if (findMessage.getSenderId() != member.getId()) {
+        if (findMessage.getReceiverId() != member.getId()) {
             throw new ForbiddenException(String.format("[%s] message id's sender is not equal with current member", id));
         }
 


### PR DESCRIPTION
(해당 이슈: #39)

1. 단일 메시지 조회 api에서 sender id 와 receiver id가 뒤바뀌어있어 있는 오류 수정
2. UUID equals 오류 수정