### PR TITLE
feat: add relationship between message and event

### DIFF
--- a/src/main/java/unithon/team5/event/controller/EventController.java
+++ b/src/main/java/unithon/team5/event/controller/EventController.java
@@ -9,34 +9,42 @@ import unithon.team5.event.dto.EventResponse;
 import unithon.team5.event.dto.TypeResponse;
 import unithon.team5.event.service.EventService;
 import unithon.team5.member.Member;
+import unithon.team5.message.dto.MessageListResponse;
 
 import java.net.URI;
 import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/events")
 public class EventController implements EventControllerDocs {
 
     private final EventService eventService;
 
-    @PostMapping("/events")
+    @PostMapping
     public ResponseEntity<Void> addEvent(@RequestBody @Valid final EventAddRequest eventAddRequest, final Member member) {
         final String uuid = eventService.addEvent(member, eventAddRequest.plannedAt(), eventAddRequest.content(), eventAddRequest.type());
         return ResponseEntity.created(URI.create("/events/" + uuid)).build();
     }
 
-    @GetMapping("/events")
+    @GetMapping
     public ResponseEntity<List<EventResponse>> readAllEvent(@RequestParam final String memberId) {
         final var events = eventService.findMemberEventAfterToday(memberId);
         final List<EventResponse> responses = EventResponse.createList(events);
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/events/types")
+    @GetMapping("/types")
     public ResponseEntity<List<TypeResponse>> readAllTypes() {
         final List<TypeResponse> responses = eventService.findEventTypeAll().stream()
                 .map(TypeResponse::from)
                 .toList();
         return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<MessageListResponse> getMessages(@RequestParam UUID eventId, final Member member) {
+        return ResponseEntity.ok(new MessageListResponse(eventService.getMessagesFromEvent(eventId, member)));
     }
 }

--- a/src/main/java/unithon/team5/event/controller/EventControllerDocs.java
+++ b/src/main/java/unithon/team5/event/controller/EventControllerDocs.java
@@ -16,8 +16,10 @@ import unithon.team5.event.dto.EventAddRequest;
 import unithon.team5.event.dto.EventResponse;
 import unithon.team5.event.dto.TypeResponse;
 import unithon.team5.member.Member;
+import unithon.team5.message.dto.MessageListResponse;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface EventControllerDocs {
 
@@ -61,6 +63,24 @@ public interface EventControllerDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SUCCESS"),
     })
-    @Operation(summary = "이벤트 조회")
+    @Operation(summary = "이벤트 타입 조회")
     ResponseEntity<List<TypeResponse>> readAllTypes();
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SUCCESS"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "403", description = "FORBIDDEN",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404", description = "NOT FOUND",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "이벤트 관련 메시지 조회")
+    ResponseEntity<MessageListResponse> getMessages(
+            @Parameter(description = "event id", example = "ete-dfdfd-fdfder", required = true)
+            @RequestParam UUID eventId,
+            @Parameter(hidden = true)
+            final Member member);
 }

--- a/src/main/java/unithon/team5/event/service/EventService.java
+++ b/src/main/java/unithon/team5/event/service/EventService.java
@@ -3,10 +3,14 @@ package unithon.team5.event.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import unithon.team5.common.error.ForbiddenException;
+import unithon.team5.common.error.NotFoundException;
 import unithon.team5.event.Event;
 import unithon.team5.event.EventType;
 import unithon.team5.event.repository.EventRepository;
 import unithon.team5.member.Member;
+import unithon.team5.message.dto.MessageResponse;
+import unithon.team5.message.repository.MessageRepository;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -18,6 +22,7 @@ import java.util.UUID;
 public class EventService {
 
     private final EventRepository eventRepository;
+    private final MessageRepository messageRepository;
 
     @Transactional
     public String addEvent(final Member member, final LocalDate plannedAt, final String content, final EventType type) {
@@ -39,6 +44,20 @@ public class EventService {
 
     public List<EventType> findEventTypeAll() {
         return Arrays.stream(EventType.values())
+                .toList();
+    }
+
+    public List<MessageResponse> getMessagesFromEvent(final UUID eventId, Member member) {
+
+        Event findEvent = eventRepository.findById(eventId).orElseThrow(
+                () -> new NotFoundException(String.format("[%s] event id not found\", message.getEventId()", eventId)));
+
+        if (!findEvent.getMemberId().equals(member.getId())) {
+            throw new ForbiddenException(String.format("[%s] event's member is not equal with current member [%s]", eventId, member.getId()));
+        }
+
+        return messageRepository.findAllByEventIdOrderBySendPlannedAtDesc(eventId)
+                .stream().map(message -> MessageResponse.of(message, findEvent))
                 .toList();
     }
 }

--- a/src/main/java/unithon/team5/message/Message.java
+++ b/src/main/java/unithon/team5/message/Message.java
@@ -21,6 +21,7 @@ public class Message extends BaseEntity {
 
     private Message(final UUID senderId,
                     final UUID receiverId,
+                    final UUID eventId,
                     final String senderName,
                     final String content,
                     final EventType type,
@@ -28,6 +29,7 @@ public class Message extends BaseEntity {
         super(null);
         this.senderId = senderId;
         this.receiverId = receiverId;
+        this.eventId = eventId;
         this.senderName = senderName;
         this.content = content;
         this.type = type;
@@ -40,6 +42,8 @@ public class Message extends BaseEntity {
 
     @Column(nullable = false, updatable = false)
     private UUID receiverId;
+
+    private UUID eventId;
 
     @Column(nullable = false)
     private String senderName;
@@ -60,10 +64,11 @@ public class Message extends BaseEntity {
 
     public static Message create(final UUID senderId,
                                  final UUID receiverId,
+                                 final UUID eventId,
                                  final String senderName,
                                  final String content,
                                  final EventType type,
                                  final LocalDate sendPlannedAt) {
-        return new Message(senderId, receiverId, senderName, content, type, sendPlannedAt);
+        return new Message(senderId, receiverId, eventId, senderName, content, type, sendPlannedAt);
     }
 }

--- a/src/main/java/unithon/team5/message/controller/MessageControllerDocs.java
+++ b/src/main/java/unithon/team5/message/controller/MessageControllerDocs.java
@@ -41,6 +41,7 @@ public interface MessageControllerDocs {
                                             {
                                             \t"receiverNickname": "nick123",
                                             \t"senderName": "보내는 닉네임",
+                                            \t"eventId": "(있는 경우만) 대상 event id",
                                             \t"content": "보낼 메시지",
                                             \t"type": "메시지 타입",
                                             \t"sendPlannedAt": "2024-04-28"
@@ -80,6 +81,7 @@ public interface MessageControllerDocs {
                                             \t\t{
                                             \t\t\t"id": "메시지 고유 UUID",
                                             \t\t\t"senderName": "보낸 사람이 설정한 닉네임",
+                                            \t\t\t"eventId": "(있는 경우만) 대상 event id",
                                             \t\t\t"content": "메시지 내용",
                                             \t\t\t"sentAt": "2024-04-06",
                                             \t\t\t"type": "메시지 타입"
@@ -87,6 +89,7 @@ public interface MessageControllerDocs {
                                             \t\t{
                                             \t\t\t"id": "메시지 고유 UUID",
                                             \t\t\t"senderName": "보낸 사람이 설정한 닉네임",
+                                            \t\t\t"eventId": "(있는 경우만) 대상 event id",
                                             \t\t\t"content": "메시지 내용",
                                             \t\t\t"sentAt": "2024-04-06",
                                             \t\t\t"type": "메시지 타입"

--- a/src/main/java/unithon/team5/message/dto/MessageEventResponse.java
+++ b/src/main/java/unithon/team5/message/dto/MessageEventResponse.java
@@ -1,0 +1,30 @@
+package unithon.team5.message.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import unithon.team5.event.Event;
+import unithon.team5.event.EventType;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageEventResponse {
+
+    private UUID id;
+    private EventType type;
+    private String content;
+    private LocalDate plannedAt;
+
+    public static MessageEventResponse of(Event event) {
+        return new MessageEventResponse(
+                event.getId(),
+                event.getType(),
+                event.getContent(),
+                event.getPlannedAt()
+        );
+    }
+}

--- a/src/main/java/unithon/team5/message/dto/MessageRequest.java
+++ b/src/main/java/unithon/team5/message/dto/MessageRequest.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.constraints.Length;
 import unithon.team5.event.EventType;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
@@ -21,6 +22,8 @@ public class MessageRequest {
 
     @NotEmpty
     private String senderName;
+
+    private UUID eventId;
 
     @NotEmpty
     @Length(max = 300)

--- a/src/main/java/unithon/team5/message/dto/MessageResponse.java
+++ b/src/main/java/unithon/team5/message/dto/MessageResponse.java
@@ -3,6 +3,7 @@ package unithon.team5.message.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import unithon.team5.event.Event;
 import unithon.team5.event.EventType;
 import unithon.team5.message.Message;
 
@@ -16,14 +17,26 @@ public class MessageResponse {
 
     private UUID id;
     private String senderName;
+    private MessageEventResponse event;
     private String content;
     private LocalDate sentAt;
     private EventType type;
 
-    public static MessageResponse of(final Message message) {
+    public static MessageResponse of(final Message message, final Event event) {
+        if (event == null) {
+            return new MessageResponse(
+                    message.getId(),
+                    message.getSenderName(),
+                    null,
+                    message.getContent(),
+                    message.getSendPlannedAt(),
+                    message.getType()
+            );
+        }
         return new MessageResponse(
                 message.getId(),
                 message.getSenderName(),
+                MessageEventResponse.of(event),
                 message.getContent(),
                 message.getSendPlannedAt(),
                 message.getType()

--- a/src/main/java/unithon/team5/message/repository/MessageRepository.java
+++ b/src/main/java/unithon/team5/message/repository/MessageRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 public interface MessageRepository extends JpaRepository<Message, UUID> {
     List<Message> findByReceiverIdAndIsReadOrderBySendPlannedAtAsc(UUID receiverId, Boolean isRead);
     List<Message> findByReceiverIdOrderBySendPlannedAtDesc(UUID receiverId);
+    List<Message> findAllByEventIdOrderBySendPlannedAtDesc(UUID eventId);
 }

--- a/src/main/java/unithon/team5/message/service/MessageService.java
+++ b/src/main/java/unithon/team5/message/service/MessageService.java
@@ -35,6 +35,7 @@ public class MessageService {
         messageRepository.save(Message.create(
                 loginMember.getId(),
                 receiver.getId(),
+                request.getEventId(),
                 request.getSenderName(),
                 request.getContent(),
                 request.getType(),


### PR DESCRIPTION
(해당 이슈: #57)
1. message, event 간 연관 관계 추가
2. 기존 message api에 event 연관 관계 추가
3. event 기반 message 조회 api 추가